### PR TITLE
added support for min and max selectable date in date-and-time.component

### DIFF
--- a/packages/components/src/widgets/date-and-time/date-and-time.component.html
+++ b/packages/components/src/widgets/date-and-time/date-and-time.component.html
@@ -13,7 +13,9 @@
                     (onSelect)="onDateChange($event)"
                     [timeOnly]="!showDate"
                     [readonlyInput]="true"
-                    [locale]="i18n">
+                    [locale]="i18n"
+                    [minDate]="minDate"
+                    [maxDate]="maxDate">
         </p-calendar>
 
         <p-calendar *ngIf="showTime"
@@ -26,7 +28,9 @@
                     [showTime]="showTime"
                     [placeholder]="timePlaceHolder"
                     (onSelect)="onDateChange($event)"
-                    [locale]="i18n">
+                    [locale]="i18n"
+                    [minDate]="minDate"
+                    [maxDate]="maxDate">
         </p-calendar>
 
     </div>

--- a/packages/components/src/widgets/date-and-time/date-and-time.component.ts
+++ b/packages/components/src/widgets/date-and-time/date-and-time.component.ts
@@ -186,6 +186,22 @@ export class DateAndTimeComponent extends BaseFormComponent {
     hourFormat: string = '24';
 
     /**
+     *
+     * Tells the date picker what is the minimum Date that could be selected(inclusive)
+     *
+     */
+    @Input()
+    minDate: Date ;
+
+    /**
+     *
+     * Tells the date picker what is the maximum Date that could be selected(inclusive)
+     *
+     */
+    @Input()
+    maxDate: Date ;
+
+    /**
      * Triggers event when specific date is clicked inside DatePicker
      *
      */

--- a/packages/components/test/widgets/date-and-time/date-and-time.component.spec.ts
+++ b/packages/components/test/widgets/date-and-time/date-and-time.component.spec.ts
@@ -88,33 +88,6 @@ describe('Component: DateAndTime', () => {
 
 
         let currentDay = fixtureWrapper.componentInstance.dateTime.value.getDate();
-        let item = fixtureWrapper.nativeElement.querySelector('.pi-calendar');
-        item.click();
-
-        tick();
-        fixtureWrapper.detectChanges();
-
-        let children = fixtureWrapper.nativeElement.querySelectorAll('a.ui-state-default')[7];
-        children.click();
-
-        tick();
-        fixtureWrapper.detectChanges();
-
-        let changedDay = fixtureWrapper.componentInstance.dateTime.value.getDate();
-        expect(changedDay).not.toEqual(currentDay);
-
-        flushMicrotasks();
-        flushPendingTimers();
-    }));
-
-    it('should change the date value when date is clicked within the range of minDate and maxDate',
-    fakeAsync(() => {
-
-        let fixtureWrapper = TestBed.createComponent(TestDateTimeMinMaxDateBehaviorComponent);
-        fixtureWrapper.detectChanges();
-
-
-        let currentDay = fixtureWrapper.componentInstance.dateTime.value.getDate();
         let minDate = fixtureWrapper.componentInstance.dateTime.minDate.getDate();
         let maxDate = fixtureWrapper.componentInstance.dateTime.maxDate.getDate();
         let item = fixtureWrapper.nativeElement.querySelector('.pi-calendar');
@@ -138,7 +111,6 @@ describe('Component: DateAndTime', () => {
         flushPendingTimers();
     }));
 
-
 });
 
 
@@ -153,22 +125,6 @@ describe('Component: DateAndTime', () => {
 })
     /* jshint ignore:end */
 class TestDateTimeBasicBehaviorComponent {
-    @ViewChild(DateAndTimeComponent)
-    dateTime: DateAndTimeComponent;
-
-    editable = true;
-    showTime = true;
-
-    date: Date = new Date();
-
-
-    constructor() {
-        this.date.setFullYear(2016, 10, 3);
-        this.date.setHours(10, 10, 10);
-    }
-}
-
-class TestDateTimeMinMaxDateBehaviorComponent {
     @ViewChild(DateAndTimeComponent)
     dateTime: DateAndTimeComponent;
 
@@ -190,7 +146,6 @@ class TestDateTimeMinMaxDateBehaviorComponent {
         this.maxDate.setHours(10, 10, 10);
     }
 }
-
 
 /* jshint ignore:start */
 @Component({

--- a/packages/components/test/widgets/date-and-time/date-and-time.component.spec.ts
+++ b/packages/components/test/widgets/date-and-time/date-and-time.component.spec.ts
@@ -107,6 +107,36 @@ describe('Component: DateAndTime', () => {
         flushPendingTimers();
     }));
 
+    it('should change the date value when date is clicked within the range of minDate and maxDate', fakeAsync(() => {
+
+        let fixtureWrapper = TestBed.createComponent(TestDateTimeMinMaxDateBehaviorComponent);
+        fixtureWrapper.detectChanges();
+
+
+        let currentDay = fixtureWrapper.componentInstance.dateTime.value.getDate();
+        let minDate = fixtureWrapper.componentInstance.dateTime.minDate.getDate();
+        let maxDate = fixtureWrapper.componentInstance.dateTime.maxDate.getDate();
+        let item = fixtureWrapper.nativeElement.querySelector('.pi-calendar');
+        item.click();
+
+        tick();
+        fixtureWrapper.detectChanges();
+
+        let children = fixtureWrapper.nativeElement.querySelectorAll('a.ui-state-default')[7];
+        children.click();
+
+        tick();
+        fixtureWrapper.detectChanges();
+
+        let changedDay = fixtureWrapper.componentInstance.dateTime.value.getDate();
+        expect(changedDay).not.toEqual(currentDay);
+        expect(changedDay).toBeGreaterThanOrEqual(minDate);
+        expect(changedDay).toBeLessThanOrEqual(maxDate);
+
+        flushMicrotasks();
+        flushPendingTimers();
+    }));
+
 
 });
 
@@ -134,6 +164,29 @@ class TestDateTimeBasicBehaviorComponent {
     constructor() {
         this.date.setFullYear(2016, 10, 3);
         this.date.setHours(10, 10, 10);
+    }
+}
+
+class TestDateTimeMinMaxDateBehaviorComponent {
+    @ViewChild(DateAndTimeComponent)
+    dateTime: DateAndTimeComponent;
+
+    editable = true;
+    showTime = true;
+
+    minDate: Date = new Date();
+    maxDate: Date = new Date();
+
+    date: Date = new Date();
+
+
+    constructor() {
+        this.date.setFullYear(2016, 10, 3);
+        this.date.setHours(10, 10, 10);
+        this.minDate.setFullYear(2016,9,1);
+        this.minDate.setHours(10,10,10);
+        this.maxDate.setFullYear(2016,11,1);
+        this.maxDate.setHours(10,10,10);
     }
 }
 

--- a/packages/components/test/widgets/date-and-time/date-and-time.component.spec.ts
+++ b/packages/components/test/widgets/date-and-time/date-and-time.component.spec.ts
@@ -107,7 +107,8 @@ describe('Component: DateAndTime', () => {
         flushPendingTimers();
     }));
 
-    it('should change the date value when date is clicked within the range of minDate and maxDate', fakeAsync(() => {
+    it('should change the date value when date is clicked within the range of minDate and maxDate',
+    fakeAsync(() => {
 
         let fixtureWrapper = TestBed.createComponent(TestDateTimeMinMaxDateBehaviorComponent);
         fixtureWrapper.detectChanges();
@@ -183,10 +184,10 @@ class TestDateTimeMinMaxDateBehaviorComponent {
     constructor() {
         this.date.setFullYear(2016, 10, 3);
         this.date.setHours(10, 10, 10);
-        this.minDate.setFullYear(2016,9,1);
-        this.minDate.setHours(10,10,10);
-        this.maxDate.setFullYear(2016,11,1);
-        this.maxDate.setHours(10,10,10);
+        this.minDate.setFullYear(2016, 9, 1);
+        this.minDate.setHours(10, 10, 10);
+        this.maxDate.setFullYear(2016, 11, 1);
+        this.maxDate.setHours(10, 10, 10);
     }
 }
 

--- a/packages/components/test/widgets/date-and-time/date-and-time.component.spec.ts
+++ b/packages/components/test/widgets/date-and-time/date-and-time.component.spec.ts
@@ -87,9 +87,9 @@ describe('Component: DateAndTime', () => {
         fixtureWrapper.detectChanges();
 
 
-        let currentDay = fixtureWrapper.componentInstance.dateTime.value.getDate();
-        let minDate = fixtureWrapper.componentInstance.dateTime.minDate.getDate();
-        let maxDate = fixtureWrapper.componentInstance.dateTime.maxDate.getDate();
+        let currentDay = fixtureWrapper.componentInstance.dateTime.value.getTime();
+        let minDate = fixtureWrapper.componentInstance.dateTime.minDate.getTime();
+        let maxDate = fixtureWrapper.componentInstance.dateTime.maxDate.getTime();
         let item = fixtureWrapper.nativeElement.querySelector('.pi-calendar');
         item.click();
 
@@ -102,7 +102,7 @@ describe('Component: DateAndTime', () => {
         tick();
         fixtureWrapper.detectChanges();
 
-        let changedDay = fixtureWrapper.componentInstance.dateTime.value.getDate();
+        let changedDay = fixtureWrapper.componentInstance.dateTime.value.getTime();
         expect(changedDay).not.toEqual(currentDay);
         expect(changedDay).toBeGreaterThanOrEqual(minDate);
         expect(changedDay).toBeLessThanOrEqual(maxDate);
@@ -118,7 +118,8 @@ describe('Component: DateAndTime', () => {
 @Component({
     selector: 'wrapper-comp',
     template: `
-        <aw-date-time [value]="date" [editable]="editable" [name]="'bbdd'">
+        <aw-date-time [value]="date" [editable]="editable" [name]="'bbdd'"
+                      [minDate]="minDate" [maxDate]="maxDate">
         </aw-date-time>
 
     `


### PR DESCRIPTION
added minDate and maxDate to DateAndTimeComponent as these are needed in cases to restrict the user from selecting dates beyond a specific preset value
This will help in cases where the selected date should be min/max some date. Eg: Date of Birth can't be greater than present date
